### PR TITLE
changed rate calculation

### DIFF
--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -13,8 +13,8 @@ use = egg:swift#proxy
 use = egg:informant#informant
 # statsd_host = 127.0.0.1
 # statsd_port = 8125
-# informant will fire an event for 1 out of every statsd_sample_rate requests
-# statsd_sample_rate = 2
+# standard statsd sample rate 0.0 <= 1
+# statsd_sample_rate = 0.5
 
 [filter:ratelimit]
 # Standard from Swift

--- a/informant/middleware.py
+++ b/informant/middleware.py
@@ -30,8 +30,10 @@ class Informant(object):
         self.statsd_host = conf.get('statsd_host', '127.0.0.1')
         self.statsd_port = int(conf.get('statsd_port', '8125'))
         self.statsd_addr = (self.statsd_host, self.statsd_port)
-        self.statsd_sample_rate = int(conf.get('statsd_sample_rate', '2'))
+        self.statsd_sample_rate = float(conf.get('statsd_sample_rate', '.5'))
+        self.actual_rate = 0.0
         self.counter = 0
+        self.monitored = 0
 
     def send_event(self, payload):
         try:
@@ -45,16 +47,17 @@ class Informant(object):
         """
         Increment multiple statsd stats counters
         """
-        # side effect of this reset is that we can't measure more than
-        # maxint requests per second.
-        if self.counter >= maxint:
-            self.counter = 0
         self.counter += 1
-        if self.counter % self.statsd_sample_rate == 0:
+        if self.actual_rate < self.statsd_sample_rate:
+            self.monitored += 1
             for item in stats:
                 payload = "%s:%s|c|@%s" % (item, delta,
                     self.statsd_sample_rate)
                 self.send_event(payload)
+        self.actual_rate = float(self.monitored) / float(self.counter)
+        if self.counter >= maxint or self.monitored >= maxint:
+            self.counter = 0
+            self.monitored = 0
 
     def statsd_event(self, env, req):
         #wrapping the *whole thing* incase something bad happens


### PR DESCRIPTION
Instead of relying on random() to fire the events, informant
now is guaranteed to send one event per X requests, where X is
the statsd_sample_rate set in the config. The side effect is that
informant will only be able to track up to sys.maxint requests per
second (this should be sufficient for most use cases).
