### PR TITLE
Adding metric name prepending, so one can easier identify metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ And add the following filter config:
     # valid_http_methods = GET,HEAD,POST,PUT,DELETE,COPY
     # send multiple statsd events per packet as supported by statsdpy
     # combined_events = no
+    # prepends name to metric collection output for easier recognition, e.g. company.swift.
+    # metric_name_prepend = 
 
 The commented out values are the defaults. This module does not require any additional statsd client modules. 
 **To utilize combined_events you'll need to run a statsd server that supports mulitple events per packet such as [statsdpy](https://github.com/pandemicsyn/statsdpyd)**

--- a/informant/middleware.py
+++ b/informant/middleware.py
@@ -37,6 +37,7 @@ class Informant(object):
                                 self.valid_methods.split(',')  if s.strip()]
         self.combined_events = conf.get(
                                 'combined_events', 'no').lower() in TRUE_VALUES
+        self.metric_name_prepend = conf.get('metric_name_prepend', '')
         self.actual_rate = 0.0
         self.counter = 0
         self.monitored = 0
@@ -98,11 +99,12 @@ class Informant(object):
                 except IndexError:
                     stat_type = 'obj'
                 metric_name = "%s.%s.%s" % (stat_type, req.method, status_int)
-                counter = "%s:1|c|@%s" % (metric_name, self.statsd_sample_rate)
-                timer = "%s:%d|ms|@%s" % (metric_name, duration,
+                counter = "%s%s:1|c|@%s" % (self.metric_name_prepend, metric_name, 
                                             self.statsd_sample_rate)
-                tfer = "tfer.%s:%s|c|@%s" % (metric_name, transferred,
-                                                self.statsd_sample_rate)
+                timer = "%s%s:%d|ms|@%s" % (self.metric_name_prepend, metric_name, duration,
+                                            self.statsd_sample_rate)
+                tfer = "%stfer.%s:%s|c|@%s" % (self.metric_name_prepend, metric_name, 
+                                                transferred, self.statsd_sample_rate)
                 self._send_events([counter, timer, tfer], self.combined_events)
         except Exception:
             try:


### PR DESCRIPTION
Found this helpful to give the metrics a better naming schema if so desired, allows you to set a config option of metric_name_prepend = cluster_name.swift. etc
