### PR TITLE
Add support for metric account name prefix's

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ And add the following filter config:
     # combine_key = \n
     # prepends name to metric collection output for easier recognition, e.g. company.swift.
     # metric_name_prepend =
+    # A list of accounts for who we'llaccount prefix the metric name with their account name
+    # This lets you track metrics for specific accounts independently.
+    # prefix_accounts = AUTH_something,
 
 The commented out values are the defaults. This module does not require any additional statsd client modules. 
 

--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -11,15 +11,17 @@ use = egg:swift#proxy
 
 [filter:informant]
 use = egg:informant#informant
-# statsd_host = 127.0.0.1
-# statsd_port = 8125
+#statsd_host = 127.0.0.1
+#statsd_port = 8125
 # standard statsd sample rate 0.0 <= 1
-# statsd_sample_rate = 0.5
+#statsd_sample_rate = 0.5
 # list of allowed methods, all others will generate a "BAD_METHOD" event
-# valid_http_methods = GET,HEAD,POST,PUT,DELETE,COPY
+#valid_http_methods = GET,HEAD,POST,PUT,DELETE,COPY
 # send multiple statsd events per packet as supported by statsdpy
-# combined_events = no
-# combine_key = \n 
+#combined_events = no
+#combine_key = \n 
+# List of accounts whos account string should be prefixed to metric names
+#prefix_accounts = AUTH_something, 
 
 [filter:ratelimit]
 # Standard from Swift

--- a/informant/__init__.py
+++ b/informant/__init__.py
@@ -2,7 +2,7 @@ import gettext
 
 
 #: Version information (major, minor, revision[, 'dev']).
-version_info = (0, 0, 10)
+version_info = (0, 0, 11)
 #: Version string 'major.minor.revision'.
 version = __version__ = ".".join(map(str, version_info))
 gettext.install('informant')

--- a/test/test_informant.py
+++ b/test/test_informant.py
@@ -43,7 +43,8 @@ class TestInformant(unittest.TestCase):
 
     def setUp(self):
         self.mock = Mocked()
-        self.app = middleware.Informant(FakeApp(), {})
+        self.app = middleware.Informant(FakeApp(),
+                                        {'prefix_accounts': 'AUTH_omgtests'})
         self.orig_send_events = self.app._send_events
         self.orig_send_sampled_event = self.app._send_sampled_event
         self.app._send_events = self.mock.fake_send_events
@@ -187,6 +188,24 @@ class TestInformant(unittest.TestCase):
         self.assertEquals(counter.startswith('obj.GET.200'), True)
         self.assertEquals(timer.startswith('obj.GET.200'), True)
         self.assertEquals(tfer.startswith('tfer.obj.GET.200:500'), True)
+
+    def test_informant_account_prefix(self):
+        req = Request.blank('/v1/AUTH_omgtests/thecont/theobj/with/extras',
+                            environ={'REQUEST_METHOD': 'GET'})
+        req.environ['informant.status'] = 200
+        req.environ['informant.start_time'] = 1331098000.00
+        req.client_disconnect = False
+        req.bytes_transferred = "500"
+        print "--> %s" % req.environ
+        resp = self.app.statsd_event(req.environ, req)
+        counter = self.mock._send_events_calls[0][0][0][0]
+        timer = self.mock._send_events_calls[0][0][0][1]
+        tfer = self.mock._send_events_calls[0][0][0][2]
+        print self.mock._send_events_calls
+        self.assertEquals(counter.startswith('AUTH_omgtests.obj.GET.200'), True)
+        self.assertEquals(timer.startswith('AUTH_omgtests.obj.GET.200'), True)
+        print tfer
+        self.assertEquals(tfer.startswith('tfer.AUTH_omgtests.obj.GET.200:500'), True)
 
     def test_informant_sos_op(self):
         req = Request.blank('/something',


### PR DESCRIPTION
You can now specify a list of account names in the config for who you'd
like to prefix metric names with their account string.
